### PR TITLE
Fix pager regex for query to accept string

### DIFF
--- a/vmtconnect/__init__.py
+++ b/vmtconnect/__init__.py
@@ -559,7 +559,7 @@ class Pager:
 
         if 'cursor' in partial:
             self.__resource, self.__query = partial.split('?', 1)
-            self.__query = re.sub(r'(?<=\?|&)cursor=([\d]+)', f"cursor={self.__next}", self.__query)
+            self.__query = re.sub(r'(?<=\?|&)cursor=(.+?)(?![^&])', f"cursor={self.__next}", self.__query)
         else:
             try:
                 self.__resource, self.__query = partial.split('?', 1)


### PR DESCRIPTION
The pager class assumed that the value for the cursor would be a number. This is incorrect as the cursor is a string and can contain other characters such as ":, ." etc. This change modifies the pager class to allow any character type in the cursor.