### PR TITLE
Fix VersionSpec to make versions optional

### DIFF
--- a/vmtconnect/__init__.py
+++ b/vmtconnect/__init__.py
@@ -377,10 +377,11 @@ class VersionSpec:
         self.allow_snapshot = snapshot
         self.cmp_base = cmp_base
 
-        try:
-            self.versions.sort()
-        except AttributeError:
-            raise VMTFormatError('Invalid input format')
+        if self.versions:
+            try:
+                self.versions.sort()
+            except AttributeError:
+                raise VMTFormatError('Invalid input format')
 
     @staticmethod
     def str_to_ver(string):
@@ -407,11 +408,12 @@ class VersionSpec:
 
     @staticmethod
     def _check(current, versions, required=True, warn=True):
-        for v in versions:
-            res = VersionSpec.cmp_ver(current, v)
+        if versions:
+            for v in versions:
+                res = VersionSpec.cmp_ver(current, v)
 
-            if (res >= 0 and v[-1] == '+') or res == 0:
-                return True
+                if (res >= 0 and v[-1] == '+') or res == 0:
+                    return True
 
         if required:
             raise VMTVersionError('Required version not met')


### PR DESCRIPTION
VersionSpec is used to control which Turbonomic instance versions the library is allowed to interact with.  "versions" specifies which versions are required and throws an error if the version is different.  "required" specifies whether or not a check for versions should be made.  This PR response an issue where "required" is set to False but vmtconnect throws a invalid format error because versions was not specified.  Since the versions are irrelevant when "required" is False, this is a bug and versions should be optional.