### PR TITLE
Updates request for empty response.

### DIFF
--- a/vmtconnect/__init__.py
+++ b/vmtconnect/__init__.py
@@ -1103,6 +1103,8 @@ class Connection:
             res = util.filter_copy(self.last_response.content.decode(),
                                    filter,
                                    use_float=filter_float)
+        elif method == "DELETE" and len(self.last_response.content) == 0:
+            res = list()
         else:
             res = self.last_response.json()
 


### PR DESCRIPTION
Modifies the `request` method to handle an empty response when a `DELETE`
operation is submitted. When the method is `DELETE`, the length of the
response content is checked. If the length is 0, an empty list is
returned.

This prevents the method from raising `requests.exceptions.JSONDecodeError`
due to attempting to parse an empty response as JSON.