### PR TITLE
Updates `get_group_by_name` to use the search method.

### DIFF
--- a/vmtconnect/__init__.py
+++ b/vmtconnect/__init__.py
@@ -1546,11 +1546,10 @@ class Connection:
         Returns:
             A list containing the group in :obj:`dict` form.
         """
-        groups = self.get_groups(**kwargs)
+        groups = self.search(types=["Group"], q=name, **kwargs)
 
-        for grp in groups:
-            if grp['displayName'] == name:
-                return [grp]
+        if isinstance(groups, list) and len(groups) > 0:
+            return [groups[0]]
 
         return None
 


### PR DESCRIPTION
The the first instance in the results is returned as a list, matching
the previous functionality. No longer uses the `get_group` method and then
doing a local match.