### PR TITLE
Updates `get_entities` paging.

### DIFF
--- a/vmtconnect/__init__.py
+++ b/vmtconnect/__init__.py
@@ -1293,12 +1293,6 @@ class Connection:
         Returns:
             A list of entities in :obj:`dict` form.
 
-
-        Notes:
-            **type** filtering is performed locally and is not compatible with
-            responses that return a :py:class:`~Pager` object. Therefore, if you
-            attempt to request a :py:class:`~Pager` response, **type** will be
-            ignored.
         """
         query = {}
 
@@ -1323,7 +1317,7 @@ class Connection:
             else:
                 entities = self.request(path, method='GET', query=query, **kwargs)
 
-        if type and isinstance(entities, Pager):
+        if type and isinstance(entities, list):
             return [deepcopy(x) for x in entities if x['className'] == type]
 
         return entities
@@ -1338,6 +1332,8 @@ class Connection:
         Returns:
             A list of virtual machines in :obj:`dict` form.
         """
+        if uuid is None:
+            kwargs["fetch_all"] = True
         return self.get_entities('VirtualMachine', uuid=uuid, market=market, **kwargs)
 
     def get_physicalmachines(self, uuid=None, market='Market', **kwargs):
@@ -1350,6 +1346,8 @@ class Connection:
         Returns:
             A list of hosts in :obj:`dict` form.
         """
+        if uuid is None:
+            kwargs["fetch_all"] = True
         return self.get_entities('PhysicalMachine', uuid=uuid, market=market, **kwargs)
 
     def get_datacenters(self, uuid=None, market='Market', **kwargs):
@@ -1362,6 +1360,8 @@ class Connection:
         Returns:
             A list of datacenters in :obj:`dict` form.
         """
+        if uuid is None:
+            kwargs["fetch_all"] = True
         return self.get_entities('DataCenter', uuid=uuid, market=market, **kwargs)
 
     def get_datastores(self, uuid=None, market='Market', **kwargs):
@@ -1374,6 +1374,8 @@ class Connection:
         Returns:
             A list of datastores in :obj:`dict` form.
         """
+        if uuid is None:
+            kwargs["fetch_all"] = True
         return self.get_entities('Storage', uuid=uuid, market=market, **kwargs)
 
     def get_clusters(self, uuid=None, cache=False, **kwargs):


### PR DESCRIPTION
Changes the expected type from `Pager` to `list`. This allows for `type` to
be combined with a lack of UUID in order to return all objects of a
given type while respecting paging. Updates the several functions which
rely on `get_entities` to specify that `fetch_all` should be added to the
`kwargs` if a UUID is omitted.