### PR TITLE
Documentation update for version 3.6.2

### DIFF
--- a/docs/source/advancedguide.rst
+++ b/docs/source/advancedguide.rst
@@ -1,13 +1,13 @@
 .. # Links
-.. _API: https://support-turbonomic.force.com/TurbonomicCustomerCommunity/s/documentation
+.. _API: https://www.ibm.com/docs/en/tarm/8.6.3?topic=api-reference
 .. _cryptography: https://pypi.org/project/cryptography/
 .. _Fernet: https://github.com/fernet/spec/blob/master/Spec.md
 .. _jq: https://stedolan.github.io/jq/
 .. _jq python: https://pypi.org/project/jq/
 .. _jq script: https://stedolan.github.io/jq/manual/
-.. _Turbonomic: https://www.turbonomic.com
-.. _Requests: https://docs.python-requests.org/en/master/
-.. _proxies: https://docs.python-requests.org/en/master/user/advanced/#proxies
+.. _Turbonomic: https://www.ibm.com/cloud/turbonomic
+.. _Requests: https://requests.readthedocs.io/en/latest/
+.. _proxies: https://requests.readthedocs.io/en/latest/user/advanced/#proxies
 .. _RFC 2732: https://datatracker.ietf.org/doc/html/rfc2732
 
 ==============

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -200,5 +200,5 @@ man_pages = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'requests': ('https://requests.readthedocs.io/en/master/', None)
+    'requests': ('https://requests.readthedocs.io/en/latest/', None)
   }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,8 +2,8 @@
    sphinx-quickstart on Tue Jul 18 10:49:54 2017.
 
 .. # Links
-.. _APIs: https://support-turbonomic.force.com/TurbonomicCustomerCommunity/s/documentation
-.. _Turbonomic: https://www.turbonomic.com
+.. _APIs: https://www.ibm.com/docs/en/tarm/8.6.3?topic=api-reference
+.. _Turbonomic: https://www.ibm.com/cloud/turbonomic
 
 ==================================
 vmt-connect Documentation Contents

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -1,12 +1,12 @@
 .. # Links
 .. _CPython: https://www.python.org/
 .. _PyPi: http://pypi.org/
-.. _Requests: https://docs.python-requests.org/en/master/
+.. _Requests: https://requests.readthedocs.io/en/latest/
 .. _IronPython: http://http://ironpython.net/
 .. _GitHub: https://github.com/turbonomic/vmt-connect
 .. _releases: https://github.com/turbonomic/vmt-connect/releases
 .. _Apache 2.0: https://www.apache.org/licenses/LICENSE-2.0.txt
-.. _Turbonomic: https://www.turbonomic.com
+.. _Turbonomic: https://www.ibm.com/cloud/turbonomic
 
 ===============
 Getting Started
@@ -37,7 +37,7 @@ Python, and install the Requests_ module.
 
   - CPython_ >= 3.6
 
-* Requests_ >= 2.21.0
+* Requests_ >= 2.25.1
 
 * Turbonomic_
 
@@ -73,13 +73,14 @@ __ releases_
 Contributors
 ============
 
-Creator and Principal Author:
-  * R.A. Stern
+Current Maintainers:
+  * John Fabry
+  * Ray Mileo
 
-Contributors:
+Past Contributors:
+  * R.A. Stern (Creator)
   * Austin Portal
   * Chris Sawtelle
-  * Ray Mileo
   * Ryan Geyer
 
 
@@ -87,8 +88,9 @@ Turbonomic REST API Guides
 ==========================
 
 The following published user guides are available to aid in developing against
-the Turbonomic REST API. Additional resources are available on the `Turbonomic Documentation <https://support-turbonomic.force.com/TurbonomicCustomerCommunity/s/documentation>`_ website.
+the Turbonomic REST API. Additional resources are available on the `Turbonomic Documentation <https://www.ibm.com/docs/en/tarm/8.6.3?topic=api-reference>`_ website.
 
+  * `XL 8.6.3 <https://www.ibm.com/docs/en/tarm/8.6.3?topic=api-reference>`_
   * `XL 8.1.0 <https://docs.turbonomic.com/pdfdocs/Turbonomic_API_PRINT_8.1.0.pdf>`_
   * `XL 8.0.1 <https://docs.turbonomic.com/docApp/doc/index.html?config=8.0.json#!/MAPPED&DEFAULT_DEDICATED_XL&showToc=1>`_
   * `XL 7.22.2 <https://docs.turbonomic.com/pdfdocs/Turbonomic_User_Guide_7.21.2.pdf>`_

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -1,6 +1,6 @@
 .. # Links
-.. _API: https://support-turbonomic.force.com/TurbonomicCustomerCommunity/s/documentation
-.. _Turbonomic: https://www.turbonomic.com
+.. _API: https://www.ibm.com/docs/en/tarm/8.6.3?topic=api-reference
+.. _Turbonomic: https://www.ibm.com/cloud/turbonomic
 
 ================
 Basic User Guide


### PR DESCRIPTION
Updates the links for Turbonomic and the Turbonomic API to point to their new addresses in IBM. Modifies how the contributors are displayed to clarify between current maintainers and previous contributors.