### PR TITLE
Modifies check for cursor in request method.

### DIFF
--- a/vmtconnect/__init__.py
+++ b/vmtconnect/__init__.py
@@ -1088,7 +1088,7 @@ class Connection:
         self.last_response = self._request(method, path, query.strip('&'), dto, **kwargs)
         self.request_check_error(self.last_response)
 
-        if pager or 'x-next-cursor' in self.last_response.headers:
+        if pager or self.last_response.headers.get('x-next-cursor'):
             res = Pager(self, self.last_response, filter, filter_float, **kwargs)
             self._clear_response(nocache)
 


### PR DESCRIPTION
Changes the request method's check for a cursor to leverage `get` rather than checking if `x-next-cursor` exists in the response headers to avoid problems when the property exists but is empty.